### PR TITLE
Deleting in map already returns bool.

### DIFF
--- a/src/services/textchannelserviceimpl.ts
+++ b/src/services/textchannelserviceimpl.ts
@@ -22,10 +22,6 @@ export class TextChannelServiceImpl implements TextChannelService {
   }
 
   public removeByChannelID(channelID: string): boolean {
-    if (!this.channels.has(channelID)) {
-      return false;
-    }
-    this.channels.delete(channelID);
-    return true;
+    return this.channels.delete(channelID);
   }
 }


### PR DESCRIPTION
This check is redundant, because according to the spec

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/delete

This is exactly the behavior of Map already.

Signed-off-by: Hanif Bin Ariffin <hanif.ariffin.4326@gmail.com>