### PR TITLE
Fix `npm run start` in Windows.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "test": "npm run lint && jest --coverage --verbose",
     "lint": "eslint --fix \"**/*.ts\"",
     "format": "prettier --write .",
-    "build-ts": "node_modules/typescript/bin/tsc",
-    "watch-ts": "node_modules/typescript/bin/tsc -w",
+    "build-ts": "tsc",
+    "watch-ts": "tsc -w",
     "debug": "npm run build && npm run watch-debug",
     "serve-debug": "nodemon --inspect dist/main.js",
     "watch-debug": "concurrently -k -p \"[{name}]\" -n \"Sass,TypeScript,Node\" -c \"yellow.bold,cyan.bold,green.bold\" \"npm run watch-sass\" \"npm run watch-ts\" \"npm run serve-debug\""


### PR DESCRIPTION
Windows apparently does not use CWD when tryng to resolving
`node_module/...`

Signed-off-by Hanif Bin Ariffin <hanif.ariffin.4326@gmail.com>